### PR TITLE
Allow server to send 0, "0", false, null

### DIFF
--- a/lib/Wrench/Connection.php
+++ b/lib/Wrench/Connection.php
@@ -350,10 +350,6 @@ class Connection extends Configurable
      */
     public function send($data, $type = Protocol::TYPE_TEXT)
     {
-        if (!$data) {
-            return false;
-        }
-
         if (!$this->handshaked) {
             throw new HandshakeException('Connection is not handshaked');
         }


### PR DESCRIPTION
This was preventing one from sending any of the following:

0, "0", "" and NULL (which is recieved as an empty string in JS clients)

The use case for this is if you want to return a count of something - 0
needs to be an option.

The use case for empty strings and NULL is to save confusion when a method is not
returning what it is expected to - having the websocket server send
nothing at all in such cases makes them difficult to debug.
