### PR TITLE
Clean up code style (examples)

### DIFF
--- a/examples/StatusApplication.php
+++ b/examples/StatusApplication.php
@@ -4,115 +4,124 @@ namespace Wrench\Application;
 /**
  * Shiny WSS Status Application
  * Provides live server infos/messages to client/browser.
- * 
+ *
  * @author Simon Samtleben <web@lemmingzshadow.net>
  */
 class StatusApplication extends Application
 {
-    private $_clients = array();
-	private $_serverClients = array();
-	private $_serverInfo = array();
-	private $_serverClientCount = 0;
+    private $_clients           = array();
+    private $_serverClients     = array();
+    private $_serverInfo        = array();
+    private $_serverClientCount = 0;
 
 
-	public function onConnect($client)
+    public function onConnect($client)
     {
-		$id = $client->getClientId();
+        $id = $client->getClientId();
         $this->_clients[$id] = $client;
-		$this->_sendServerinfo($client);
+        $this->_sendServerinfo($client);
     }
 
     public function onDisconnect($client)
     {
-        $id = $client->getClientId();		
-		unset($this->_clients[$id]);     
+        $id = $client->getClientId();
+        unset($this->_clients[$id]);
     }
 
     public function onData($data, $client)
-    {		
+    {
         // currently not in use...
     }
-	
-	public function setServerInfo($serverInfo)
-	{
-		if(is_array($serverInfo))
-		{
-			$this->_serverInfo = $serverInfo;
-			return true;
-		}
-		return false;
-	}
+
+    public function setServerInfo($serverInfo)
+    {
+        if (is_array($serverInfo)) {
+            $this->_serverInfo = $serverInfo;
+            return true;
+        }
+
+        return false;
+    }
 
 
-	public function clientConnected($ip, $port)
-	{
-		$this->_serverClients[$port] = $ip;
-		$this->_serverClientCount++;
-		$this->statusMsg('Client connected: ' .$ip.':'.$port);
-		$data = array(
-			'ip' => $ip,
-			'port' => $port,
-			'clientCount' => $this->_serverClientCount,
-		);
-		$encodedData = $this->_encodeData('clientConnected', $data);
-		$this->_sendAll($encodedData);
-	}
-	
-	public function clientDisconnected($ip, $port)
-	{
-		if(!isset($this->_serverClients[$port]))
-		{
-			return false;
-		}
-		unset($this->_serverClients[$port]);
-		$this->_serverClientCount--;
-		$this->statusMsg('Client disconnected: ' .$ip.':'.$port);
-		$data = array(			
-			'port' => $port,
-			'clientCount' => $this->_serverClientCount,
-		);
-		$encodedData = $this->_encodeData('clientDisconnected', $data);
-		$this->_sendAll($encodedData);
-	}
-	
-	public function clientActivity($port)
-	{
-		$encodedData = $this->_encodeData('clientActivity', $port);
-		$this->_sendAll($encodedData);
-	}
+    public function clientConnected($ip, $port)
+    {
+        $this->_serverClients[$port] = $ip;
+        $this->_serverClientCount++;
+        $this->statusMsg('Client connected: ' . $ip . ':' . $port);
 
-	public function statusMsg($text, $type = 'info')
-	{		
-		$data = array(
-			'type' => $type,
-			'text' => '['. strftime('%m-%d %H:%M', time()) . '] ' . $text,
-		);
-		$encodedData = $this->_encodeData('statusMsg', $data);		
-		$this->_sendAll($encodedData);
-	}
-	
-	private function _sendServerinfo($client)
-	{
-		if(count($this->_clients) < 1)
-		{
-			return false;
-		}
-		$currentServerInfo = $this->_serverInfo;
-		$currentServerInfo['clientCount'] = count($this->_serverClients);
-		$currentServerInfo['clients'] = $this->_serverClients;
-		$encodedData = $this->_encodeData('serverInfo', $currentServerInfo);
-		$client->send($encodedData);
-	}
-	
-	private function _sendAll($encodedData)
-	{		
-		if(count($this->_clients) < 1)
-		{
-			return false;
-		}
-		foreach($this->_clients as $sendto)
-		{
+        $data = array(
+            'ip' => $ip,
+            'port' => $port,
+            'clientCount' => $this->_serverClientCount,
+        );
+
+        $encodedData = $this->_encodeData('clientConnected', $data);
+
+        $this->_sendAll($encodedData);
+    }
+
+    public function clientDisconnected($ip, $port)
+    {
+        if (!isset($this->_serverClients[$port])) {
+            return false;
+        }
+
+        unset($this->_serverClients[$port]);
+
+        $this->_serverClientCount--;
+        $this->statusMsg('Client disconnected: ' . $ip . ':' . $port);
+
+        $data = array(
+            'port' => $port,
+            'clientCount' => $this->_serverClientCount,
+        );
+
+        $encodedData = $this->_encodeData('clientDisconnected', $data);
+
+        $this->_sendAll($encodedData);
+    }
+
+    public function clientActivity($port)
+    {
+        $encodedData = $this->_encodeData('clientActivity', $port);
+        $this->_sendAll($encodedData);
+    }
+
+    public function statusMsg($text, $type = 'info')
+    {
+        $data = array(
+            'type' => $type,
+            'text' => '[' . strftime('%m-%d %H:%M', time()) . '] ' . $text,
+        );
+
+        $encodedData = $this->_encodeData('statusMsg', $data);
+
+        $this->_sendAll($encodedData);
+    }
+
+    private function _sendServerinfo($client)
+    {
+        if (count($this->_clients) < 1) {
+            return false;
+        }
+
+        $currentServerInfo                = $this->_serverInfo;
+        $currentServerInfo['clientCount'] = count($this->_serverClients);
+        $currentServerInfo['clients']     = $this->_serverClients;
+        $encodedData                      = $this->_encodeData('serverInfo', $currentServerInfo);
+
+        $client->send($encodedData);
+    }
+
+    private function _sendAll($encodedData)
+    {
+        if (count($this->_clients) < 1) {
+            return false;
+        }
+
+        foreach ($this->_clients as $sendto) {
             $sendto->send($encodedData);
         }
-	}
+    }
 }

--- a/examples/coffeescript/coffee/client.coffee
+++ b/examples/coffeescript/coffee/client.coffee
@@ -1,39 +1,38 @@
 $(document).ready ->
-	log = (msg) -> $('#log').append("#{msg}<br />")	
-	serverUrl = 'ws://127.0.0.1:8000/demo'
-	if window.MozWebSocket		
-		socket = new MozWebSocket serverUrl
-	else if window.WebSocket		
-		socket = new WebSocket serverUrl
-	socket.binaryType = 'blob'
+  log = (msg) -> $('#log').append("#{msg}<br />")
+  serverUrl = 'ws://127.0.0.1:8000/demo'
+  if window.MozWebSocket
+    socket = new MozWebSocket serverUrl
+  else if window.WebSocket
+    socket = new WebSocket serverUrl
+  socket.binaryType = 'blob'
 
-	socket.onopen = (msg) ->
-		$('#status').removeClass().addClass('online').html('connected')
-	
-	socket.onmessage = (msg) ->
-		response = JSON.parse(msg.data)
-		log("Action: #{response.action}")
-		log("Data: #{response.data}")
-	
-	socket.onclose = (msg) ->
-		$('#status').removeClass().addClass('offline').html('disconnected')
-	
-	$('#status').click ->
-		socket.close()
-	
-	$('#send').click ->
-		payload = new Object()
-		payload.action = $('#action').val()
-		payload.data = $('#data').val()
-		socket.send(JSON.stringify(payload))
-		
-	$('#sendfile').click ->
-		data = document.binaryFrame.file.files[0]
-		if data			
-			payload = new Object()
-			payload.action = 'setFilename'
-			payload.data = $('#file').val()			
-			socket.send JSON.stringify payload			
-			socket.send(data)
-		return false
-		
+  socket.onopen = (msg) ->
+    $('#status').removeClass().addClass('online').html('connected')
+
+  socket.onmessage = (msg) ->
+    response = JSON.parse(msg.data)
+    log("Action: #{response.action}")
+    log("Data: #{response.data}")
+
+  socket.onclose = (msg) ->
+    $('#status').removeClass().addClass('offline').html('disconnected')
+
+  $('#status').click ->
+    socket.close()
+
+  $('#send').click ->
+    payload = new Object()
+    payload.action = $('#action').val()
+    payload.data = $('#data').val()
+    socket.send(JSON.stringify(payload))
+
+  $('#sendfile').click ->
+    data = document.binaryFrame.file.files[0]
+    if data
+      payload = new Object()
+      payload.action = 'setFilename'
+      payload.data = $('#file').val()
+      socket.send JSON.stringify payload
+      socket.send(data)
+    return false

--- a/examples/coffeescript/coffee/status.coffee
+++ b/examples/coffeescript/coffee/status.coffee
@@ -1,51 +1,51 @@
 $(document).ready ->
-	log = (msg) -> $('#log').prepend("#{msg}<br />")	
-	serverUrl = 'ws://localhost:8000/status'
-	if window.MozWebSocket		
-		socket = new MozWebSocket serverUrl
-	else if window.WebSocket		
-		socket = new WebSocket serverUrl
+  log = (msg) -> $('#log').prepend("#{msg}<br />")
+  serverUrl = 'ws://localhost:8000/status'
+  if window.MozWebSocket
+    socket = new MozWebSocket serverUrl
+  else if window.WebSocket
+    socket = new WebSocket serverUrl
 
-	socket.onopen = (msg) ->
-		$('#status').removeClass().addClass('online').html('connected')
+  socket.onopen = (msg) ->
+    $('#status').removeClass().addClass('online').html('connected')
 
-	socket.onmessage = (msg) ->
-		response = JSON.parse(msg.data)
-		switch response.action
-			when "statusMsg"			then statusMsg response.data
-			when "clientConnected"		then clientConnected response.data
-			when "clientDisconnected"	then clientDisconnected response.data			
-			when "clientActivity"		then clientActivity response.data
-			when "serverInfo"			then refreshServerinfo response.data
+  socket.onmessage = (msg) ->
+    response = JSON.parse(msg.data)
+    switch response.action
+      when "statusMsg"      then statusMsg response.data
+      when "clientConnected"    then clientConnected response.data
+      when "clientDisconnected"  then clientDisconnected response.data
+      when "clientActivity"    then clientActivity response.data
+      when "serverInfo"      then refreshServerinfo response.data
 
-	socket.onclose = (msg) ->
-		$('#status').removeClass().addClass('offline').html('disconnected')
+  socket.onclose = (msg) ->
+    $('#status').removeClass().addClass('offline').html('disconnected')
 
-	$('#status').click ->
-		socket.close()
+  $('#status').click ->
+    socket.close()
 
-	statusMsg = (msgData) ->
-		switch msgData.type
-			when "info" then log msgData.text
-			when "warning" then log "<span class=\"warning\">#{msgData.text}</span>"
+  statusMsg = (msgData) ->
+    switch msgData.type
+      when "info" then log msgData.text
+      when "warning" then log "<span class=\"warning\">#{msgData.text}</span>"
 
-	clientConnected = (data) ->		
-		$('#clientListSelect').append(new Option("#{data.ip}:#{data.port}", data.port))
-		$('#clientCount').text(data.clientCount)
+  clientConnected = (data) ->
+    $('#clientListSelect').append(new Option("#{data.ip}:#{data.port}", data.port))
+    $('#clientCount').text(data.clientCount)
 
-	clientDisconnected = (data) ->
-		$("#clientListSelect option[value='#{data.port}']").remove()
-		$('#clientCount').text(data.clientCount)
+  clientDisconnected = (data) ->
+    $("#clientListSelect option[value='#{data.port}']").remove()
+    $('#clientCount').text(data.clientCount)
 
-	refreshServerinfo = (serverinfo) ->	
-		$('#clientCount').text(serverinfo.clientCount)
-		$('#maxClients').text(serverinfo.maxClients)
-		$('#maxConnections').text(serverinfo.maxConnectionsPerIp)
-		$('#maxRequetsPerMinute').text(serverinfo.maxRequetsPerMinute)
-		for port, ip of serverinfo.clients			
-			$('#clientListSelect').append(new Option(ip + ':' + port, port));	
+  refreshServerinfo = (serverinfo) ->
+    $('#clientCount').text(serverinfo.clientCount)
+    $('#maxClients').text(serverinfo.maxClients)
+    $('#maxConnections').text(serverinfo.maxConnectionsPerIp)
+    $('#maxRequetsPerMinute').text(serverinfo.maxRequetsPerMinute)
+    for port, ip of serverinfo.clients
+      $('#clientListSelect').append(new Option(ip + ':' + port, port));
 
-	clientActivity = (port) ->
-		$("#clientListSelect option[value='#{port}']").css("color", "red").animate({opacity: 100}, 600, ->
-			$(this).css("color", "black")
-		)
+  clientActivity = (port) ->
+    $("#clientListSelect option[value='#{port}']").css("color", "red").animate({opacity: 100}, 600, ->
+      $(this).css("color", "black")
+    )

--- a/examples/coffeescript/index.html
+++ b/examples/coffeescript/index.html
@@ -1,34 +1,36 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<link rel="stylesheet" href="css/client.css">
-	
-    <script src="js/jquery.min.js"></script>
-	<script src="js/json2.js"></script>
-	<script src="lib/coffeescript/jsmaker.php?f=client.coffee"></script>
-    
-	<meta charset=utf-8 />
+    <link rel="stylesheet" href="css/client.css">
 
-	<title>Shiny WSS Demo Application</title>
+    <script src="js/jquery.min.js"></script>
+    <script src="js/json2.js"></script>
+    <script src="lib/coffeescript/jsmaker.php?f=client.coffee"></script>
+
+    <meta charset=utf-8/>
+
+    <title>Shiny WSS Demo Application</title>
 </head>
 <body>
-    <div id="container">
-        <h1>Shiny WSS Demo Application</h1>
-		<span id="status" class="offline">offline</span>
-		
-		<h2>Send Text Frame</h2>
-		<input id="action" placeholder="action" type="text" />
-        <input id="data" placeholder="data" type="text" />
-        <button id="send">Send Text</button>
-		
-		<h2>Send Binary Frame</h2>
-		<form name="binaryFrame" action="#">
-			<input type="file" name="file" id="file">
-			<button id="sendfile">Send Binary</button>
-		</form>
-		
-		<h2>Server-Response</h2>
-        <div id="log"></div>
-    </div>
+<div id="container">
+    <h1>Shiny WSS Demo Application</h1>
+    <span id="status" class="offline">offline</span>
+
+    <h2>Send Text Frame</h2>
+    <input id="action" placeholder="action" type="text"/>
+    <input id="data" placeholder="data" type="text"/>
+    <button id="send">Send Text</button>
+
+    <h2>Send Binary Frame</h2>
+
+    <form name="binaryFrame" action="#">
+        <input type="file" name="file" id="file">
+        <button id="sendfile">Send Binary</button>
+    </form>
+
+    <h2>Server-Response</h2>
+
+    <div id="log"></div>
+</div>
 </body>
 </html>​

--- a/examples/coffeescript/status.html
+++ b/examples/coffeescript/status.html
@@ -1,42 +1,47 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<link rel="stylesheet" href="css/status.css">
-	
-    <script src="js/jquery.min.js"></script>
-	<script src="js/json2.js"></script>
-	<script src="lib/coffeescript/jsmaker.php?f=status.coffee"></script>
-    
-	<meta charset=utf-8 />
+    <link rel="stylesheet" href="css/status.css">
 
-	<title>Shiny WSS Status</title>
+    <script src="js/jquery.min.js"></script>
+    <script src="js/json2.js"></script>
+    <script src="lib/coffeescript/jsmaker.php?f=status.coffee"></script>
+
+    <meta charset=utf-8/>
+
+    <title>Shiny WSS Status</title>
 </head>
 <body>
-    <div id="container">
-        <h1>Shiny WSS Status</h1>
-		<span id="status" class="offline">disconnected</span>
-		
-		<div id="main">
-			<div id="clientList">
-				<h2>Clients:</h2>
-				<select id="clientListSelect" multiple="multiple"></select>
-			</div>
+<div id="container">
+    <h1>Shiny WSS Status</h1>
+    <span id="status" class="offline">disconnected</span>
 
-			<div id="serverInfo">
-				<h2>Server Info:</h2>
-				<p>Connected Clients: <span id="clientCount"></span></p>
-				<p>Limit Clients: <span id="maxClients"></span></p>
-				<p>Limit Connections/IP: <span id="maxConnections"></span></p>
-				<p>Limit Requetes/Min: <span id="maxRequetsPerMinute"></span></p>
-			</div>
-			
-			<div class="clearer"></div>
-			
-			<div id="console">
-				<h2>Server Messages:</h2>
-				<div id="log"></div>
-			</div>
-		</div>			
+    <div id="main">
+        <div id="clientList">
+            <h2>Clients:</h2>
+            <select id="clientListSelect" multiple="multiple"></select>
+        </div>
+
+        <div id="serverInfo">
+            <h2>Server Info:</h2>
+
+            <p>Connected Clients: <span id="clientCount"></span></p>
+
+            <p>Limit Clients: <span id="maxClients"></span></p>
+
+            <p>Limit Connections/IP: <span id="maxConnections"></span></p>
+
+            <p>Limit Requetes/Min: <span id="maxRequetsPerMinute"></span></p>
+        </div>
+
+        <div class="clearer"></div>
+
+        <div id="console">
+            <h2>Server Messages:</h2>
+
+            <div id="log"></div>
+        </div>
     </div>
+</div>
 </body>
 </html>​

--- a/examples/server_ssl.php
+++ b/examples/server_ssl.php
@@ -14,26 +14,26 @@ $classLoader = new SplClassLoader('Wrench', __DIR__ . '/../lib');
 $classLoader->register();
 
 // Generate PEM file
-$pemFile = dirname(__FILE__).'/generated.pem';
-$pemPassphrase = null;
-$countryName = "DE";
-$stateOrProvinceName = "none";
-$localityName = "none";
-$organizationName = "none";
+$pemFile                = dirname(__FILE__) . '/generated.pem';
+$pemPassphrase          = null;
+$countryName            = "DE";
+$stateOrProvinceName    = "none";
+$localityName           = "none";
+$organizationName       = "none";
 $organizationalUnitName = "none";
-$commonName =  "foo.lh";
-$emailAddress = "baz@foo.lh";
+$commonName             = "foo.lh";
+$emailAddress           = "baz@foo.lh";
 
 \Wrench\Socket::generatePEMFile(
-	$pemFile, 
-	$pemPassphrase, 
-	$countryName, 
-	$stateOrProvinceName, 
-	$localityName, 
-	$organizationName, 
-	$organizationalUnitName,
-	$commonName,
-	$emailAddress
+    $pemFile,
+    $pemPassphrase,
+    $countryName,
+    $stateOrProvinceName,
+    $localityName,
+    $organizationName,
+    $organizationalUnitName,
+    $commonName,
+    $emailAddress
 );
 
 // User can use tls in place of ssl


### PR DESCRIPTION
Use whitespace for tabs.  Make code more readable.  Tabs mixed with whitespace was causing github.com to display the code all weird like.
