### PR TITLE
Added use of HandshakeException

### DIFF
--- a/lib/Wrench/Protocol/Protocol.php
+++ b/lib/Wrench/Protocol/Protocol.php
@@ -5,6 +5,7 @@ namespace Wrench\Protocol;
 use Wrench\Payload\Payload;
 
 use Wrench\Exception\BadRequestException;
+use Wrench\Exception\HandshakeException;
 
 use \Exception;
 use \InvalidArgumentException;


### PR DESCRIPTION
In Protocol class, function validateResponseHandshake throw HandshakeException, which was not declared as used
