### PR TITLE
socket_last_error requires the socket extension to be enabled @see Wrench\Socket\Socket.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.3",
+        "ext-sockets": "*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
The call to @socket_last_error crashes when the socket extension is not enabled.
