### PR TITLE
Catch InvalidArgumentException

### DIFF
--- a/lib/Wrench/ConnectionManager.php
+++ b/lib/Wrench/ConnectionManager.php
@@ -249,6 +249,9 @@ class ConnectionManager extends Configurable implements Countable
         } catch (WrenchException $e) {
             $this->log('Error on client socket: ' . $e, 'warning');
             $connection->close($e);
+        } catch (\InvalidArgumentException $e) {
+            $this->log('Wrong input arguments: ' . $e, 'warning');
+            $connection->close($e);
         }
     }
 


### PR DESCRIPTION
Hello guys!
I think it could be related with #15
Steps to reproduce this crash:
- launch a server (just server.php from example)
- send wrong header (without \r\n):

`printf "GET / HTTP/1.0" | nc localhost 8000`

At this moment wrench tries to check header:
Method [validateRequestHandshake](https://github.com/varspool/Wrench/blob/master/lib/Wrench/Connection.php#L227) uses [getRequestHeaders](https://github.com/varspool/Wrench/blob/master/lib/Wrench/Protocol/Protocol.php#L720) and if there is no `"\r\n"` in `$response` it throws `InvalidArgumentException:`

``` php
       if ($eol === false) {
            throw new InvalidArgumentException('Invalid request line');
        }
```

The main problem is that nobody catches this exception! =(

There are a lot of methods to solve this problem:
- change exception class
- add catching somewhere else
- catch main exception class from user application (server.php for example)

If you have other opinion about this problem, just say =)
