### PR TITLE
listen() fix

### DIFF
--- a/lib/Wrench/Socket/ServerSocket.php
+++ b/lib/Wrench/Socket/ServerSocket.php
@@ -58,7 +58,7 @@ class ServerSocket extends UriSocket
             $this->getUri(),
             $errno,
             $errstr,
-            STREAM_SERVER_BIND|STREAM_SERVER_LISTEN.
+            STREAM_SERVER_BIND|STREAM_SERVER_LISTEN,
             $this->getStreamContext()
         );
 


### PR DESCRIPTION
Fixes 
Warning: stream_socket_accept(): SSL_R_NO_SHARED_CIPHER: no suitable shared cipher could be used.  This could be because the server is missing an SSL certificate (local_cert context option) in .../lib/Wrench/Socket/ServerSocket.php on line 87
