### PR TITLE
Rate limiter fixes suggested by @supipd

### DIFF
--- a/lib/Wrench/BasicServer.php
+++ b/lib/Wrench/BasicServer.php
@@ -29,10 +29,15 @@ class BasicServer extends Server
     protected function configure(array $options)
     {
         $options = array_merge(array(
-            'check_origin'        => true,
-            'allowed_origins'     => array(),
-            'origin_policy_class' => 'Wrench\Listener\OriginPolicy',
-            'rate_limiter_class'  => 'Wrench\Listener\RateLimiter'
+            'check_origin'         => true,
+            'allowed_origins'      => array(),
+            'origin_policy_class'  => 'Wrench\Listener\OriginPolicy',
+            'rate_limiter_class'   => 'Wrench\Listener\RateLimiter',
+            'rate_limiter_options' => array(
+                'connections'         => 200, // Total
+                'connections_per_ip'  => 5,   // At once
+                'requests_per_minute' => 200  // Per connection
+            )
         ), $options);
 
         parent::configure($options);
@@ -41,7 +46,7 @@ class BasicServer extends Server
     protected function configureRateLimiter()
     {
         $class = $this->options['rate_limiter_class'];
-        $this->rateLimiter = new $class();
+        $this->rateLimiter = new $class($this->options['rate_limiter_options']);
         $this->rateLimiter->listen($this);
     }
 

--- a/lib/Wrench/ConnectionManager.php
+++ b/lib/Wrench/ConnectionManager.php
@@ -241,6 +241,8 @@ class ConnectionManager extends Configurable implements Countable
         }
 
         try {
+            $this->server->notify(Server::EVENT_CLIENT_DATA, array($socket, $connection));
+
             $connection->process();
         } catch (CloseException $e) {
             $this->log('Client connection closed: ' . $e, 'notice');


### PR DESCRIPTION
- Allows configuration of the rate limiter options through the BasicServer's options
- Fixes the lack of a `CLIENT_DATA` event!

Should fix #33

(I basically just converted the exact diffs from that issue into this patch.)
