### PR TITLE
Fix off-by-one error in deciding to exit length calculation

### DIFF
--- a/lib/Wrench/Frame/HybiFrame.php
+++ b/lib/Wrench/Frame/HybiFrame.php
@@ -263,7 +263,7 @@ class HybiFrame extends Frame
                 $start = self::BYTE_INITIAL_LENGTH + 1;
                 $end = self::BYTE_INITIAL_LENGTH + $this->getLengthSize();
 
-                if ($end > $this->getBufferLength()) {
+                if ($end >= $this->getBufferLength()) {
                     throw new FrameException('Cannot get extended length: need more data');
                 }
 


### PR DESCRIPTION
The foreach starting at line 271 shouldn't be entered unless it is known $this->buffer[$start] through $this->buffer[$end] is set, inclusive (this is the range in the frame that holds the payload length).

Previously, we tested if `$end > strlen($this->buffer)`. Consider the case when `$end == strlen($this->buffer)`: $this->buffer[$end] is not set (because indexes start at zero). We should therefore instead test for `$end >= strlen($this->buffer)`.

Potentially fixes #35 and #61
