### PR TITLE
unblocking read from socket when it the queue is empty

### DIFF
--- a/lib/Wrench/Socket/Socket.php
+++ b/lib/Wrench/Socket/Socket.php
@@ -320,7 +320,13 @@ abstract class Socket extends Configurable implements Resource
 
             if ($metadata && isset($metadata['unread_bytes']) && $metadata['unread_bytes']) {
                 $continue = true;
-                $length = $metadata['unread_bytes'];
+                // it makes sense only if unread_bytes less than DEFAULT_RECEIVE_LENGTH
+                if ($length > $metadata['unread_bytes']) {
+                    $length = $metadata['unread_bytes'];
+                    // Socket is a blocking by default. When we do a blocking read from an empty
+                    // queue it will block and the server will hang. https://bugs.php.net/bug.php?id=1739
+                    stream_set_blocking($this->socket, false);
+                }
             }
         } while ($continue);
 

--- a/lib/Wrench/Socket/Socket.php
+++ b/lib/Wrench/Socket/Socket.php
@@ -318,15 +318,21 @@ abstract class Socket extends Configurable implements Resource
             // Continue if more data to be read
             $metadata = stream_get_meta_data($this->socket);
 
-            if ($metadata && isset($metadata['unread_bytes']) && $metadata['unread_bytes']) {
-                $continue = true;
-                // it makes sense only if unread_bytes less than DEFAULT_RECEIVE_LENGTH
-                if ($length > $metadata['unread_bytes']) {
-                    $length = $metadata['unread_bytes'];
-                    // Socket is a blocking by default. When we do a blocking read from an empty
-                    // queue it will block and the server will hang. https://bugs.php.net/bug.php?id=1739
-                    stream_set_blocking($this->socket, false);
-                }
+            if ($metadata && isset($metadata['unread_bytes'])) {
+            	if (!$metadata['unread_bytes']) {
+            		// stop it, if we read a full message in previous time
+            		$continue = false;
+            	}
+            	else {
+	                $continue = true;
+	                // it makes sense only if unread_bytes less than DEFAULT_RECEIVE_LENGTH
+	                if ($length > $metadata['unread_bytes']) {
+	                    $length = $metadata['unread_bytes'];
+	                    // Socket is a blocking by default. When we do a blocking read from an empty
+	                    // queue it will block and the server will hang. https://bugs.php.net/bug.php?id=1739
+	                    stream_set_blocking($this->socket, false);
+	                }
+            	}
             }
         } while ($continue);
 


### PR DESCRIPTION
If we send a message more then DEFAULT_RECEIVE_LENGTH server hangs on the second attempt to read
