### PR TITLE
Handle all header fields case-insensitively.

### DIFF
--- a/lib/Wrench/Protocol/Protocol.php
+++ b/lib/Wrench/Protocol/Protocol.php
@@ -737,7 +737,7 @@ abstract class Protocol
         $request = substr($response, 0, $eol);
         $headers = $this->getHeaders(substr($response, $eol + 2));
 
-        return array($request, array_change_key_case($headers));
+        return array($request, $headers);
     }
 
     /**

--- a/lib/Wrench/Protocol/Protocol.php
+++ b/lib/Wrench/Protocol/Protocol.php
@@ -32,15 +32,15 @@ abstract class Protocol
      *
      * @var string
      */
-    const HEADER_HOST       = 'Host';
-    const HEADER_KEY        = 'Sec-WebSocket-Key';
-    const HEADER_PROTOCOL   = 'Sec-WebSocket-Protocol';
-    const HEADER_VERSION    = 'Sec-WebSocket-Version';
-    const HEADER_ACCEPT     = 'Sec-WebSocket-Accept';
-    const HEADER_EXTENSIONS = 'Sec-WebSocket-Extensions';
-    const HEADER_ORIGIN     = 'Origin';
-    const HEADER_CONNECTION = 'Connection';
-    const HEADER_UPGRADE    = 'Upgrade';
+    const HEADER_HOST       = 'host';
+    const HEADER_KEY        = 'sec-websocket-key';
+    const HEADER_PROTOCOL   = 'sec-websocket-protocol';
+    const HEADER_VERSION    = 'sec-websocket-version';
+    const HEADER_ACCEPT     = 'sec-websocket-accept';
+    const HEADER_EXTENSIONS = 'sec-websocket-extensions';
+    const HEADER_ORIGIN     = 'origin';
+    const HEADER_CONNECTION = 'connection';
+    const HEADER_UPGRADE    = 'upgrade';
     /**#@-*/
 
     /**#@+
@@ -415,7 +415,7 @@ abstract class Protocol
 
         $expected = $this->getAcceptValue($key);
 
-        preg_match('#Sec-WebSocket-Accept:\s(.*)$#mU', $response, $matches);
+        preg_match('#Sec-WebSocket-Accept:\s(.*)$#imU', $response, $matches);
         $keyAccept = trim($matches[1]);
 
         return ($keyAccept === $this->getEncodedHash($key)) ? true : false;
@@ -715,7 +715,7 @@ abstract class Protocol
             }
         }
 
-        return $return;
+        return array_change_key_case($return);
     }
 
     /**
@@ -737,7 +737,7 @@ abstract class Protocol
         $request = substr($response, 0, $eol);
         $headers = $this->getHeaders(substr($response, $eol + 2));
 
-        return array($request, $headers);
+        return array($request, array_change_key_case($headers));
     }
 
     /**

--- a/lib/Wrench/Tests/ConnectionTest.php
+++ b/lib/Wrench/Tests/ConnectionTest.php
@@ -78,7 +78,7 @@ class ConnectionTest extends Test
         $connection->handshake($request);
 
         $headers = $connection->getHeaders();
-        $this->assertEquals(array('X-Some-Header' => 'Some Value'), $headers, 'Extra headers returned');
+        $this->assertEquals(array_change_key_case(array('X-Some-Header' => 'Some Value')), $headers, 'Extra headers returned');
 
         $params = $connection->getQueryParams();
         $this->assertEquals(array('someparam' => 'someval'), $params, 'Query string parameters returned');


### PR DESCRIPTION
- lowercase defined header constants
- apply `array_change_key_case` to $headers
