### PR TITLE
Add a loop object to allow customizing when the server stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Dropped support for PHP versions prior to 7.1
 * Moved to PSR4 layout, with a separate test directory (this means test code cannot be autoloaded in production, much nicer)
 * Added support for PSR3 everywhere that we used to accept a logging callback (just inject via LoggerAwareInterface)
+* Added support for users of the Server class to determine when the main server loop ends. (Thanks @Alarmfifa - #77)
 
 #### BC Breaks
 

--- a/lib/ConnectionManager.php
+++ b/lib/ConnectionManager.php
@@ -12,6 +12,7 @@ use Wrench\Application\ConnectionHandlerInterface;
 use Wrench\Application\DataHandlerInterface;
 use Wrench\Application\UpdateHandlerInterface;
 use Wrench\Exception\CloseException;
+use Wrench\Exception\ConnectionException;
 use Wrench\Exception\Exception as WrenchException;
 use Wrench\Socket\ServerClientSocket;
 use Wrench\Socket\ServerSocket;
@@ -88,7 +89,7 @@ class ConnectionManager extends Configurable implements Countable, LoggerAwareIn
      * Listens on the main socket
      *
      * @return void
-     * @throws Exception\ConnectionException
+     * @throws ConnectionException
      */
     public function listen(): void
     {
@@ -224,7 +225,7 @@ class ConnectionManager extends Configurable implements Countable, LoggerAwareIn
                 'exception' => $e,
             ]);
             $connection->close($e);
-        } catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             $this->logger->warning('Wrong input arguments: {exception}', [
                 'exception' => $e,
             ]);
@@ -238,10 +239,10 @@ class ConnectionManager extends Configurable implements Countable, LoggerAwareIn
      * @param resource $socket
      * @return Connection
      */
-    protected function getConnectionForClientSocket($socket)
+    protected function getConnectionForClientSocket($socket): ?Connection
     {
         if (!isset($this->connections[$this->resourceId($socket)])) {
-            return false;
+            return null;
         }
         return $this->connections[$this->resourceId($socket)];
     }
@@ -257,9 +258,9 @@ class ConnectionManager extends Configurable implements Countable, LoggerAwareIn
     }
 
     /**
-     * @return \Wrench\Server
+     * @return Server
      */
-    public function getServer()
+    public function getServer(): Server
     {
         return $this->server;
     }
@@ -269,7 +270,7 @@ class ConnectionManager extends Configurable implements Countable, LoggerAwareIn
      *
      * @param Connection $connection
      */
-    public function removeConnection(Connection $connection)
+    public function removeConnection(Connection $connection): void
     {
         $socket = $connection->getSocket();
 
@@ -293,8 +294,8 @@ class ConnectionManager extends Configurable implements Countable, LoggerAwareIn
     }
 
     /**
-     * @see Socket::configure()
-     *   Options include:
+     * @param array $options
+     *     Options include:
      *     - timeout_select          => int, seconds, default 0
      *     - timeout_select_microsec => int, microseconds (NB: not milli), default: 200000
      */

--- a/lib/Server.php
+++ b/lib/Server.php
@@ -236,6 +236,7 @@ class Server extends Configurable implements LoggerAwareInterface
     protected function configure(array $options): void
     {
         $options = array_merge([
+            'connection_manager' => null,
             'connection_manager_class' => ConnectionManager::class,
             'connection_manager_options' => [],
         ], $options);
@@ -252,9 +253,15 @@ class Server extends Configurable implements LoggerAwareInterface
      */
     protected function configureConnectionManager(): void
     {
-        $class = $this->options['connection_manager_class'];
-        $options = $this->options['connection_manager_options'];
-        $this->connectionManager = new $class($this, $options);
+        if ($this->options['connection_manager']) {
+            $this->connectionManager = $this->options['connection_manager'];
+        } else {
+            $class = $this->options['connection_manager_class'];
+            $options = $this->options['connection_manager_options'];
+
+            $this->connectionManager = new $class($this, $options);
+        }
+
         $this->connectionManager->setLogger($this->logger);
     }
 }

--- a/lib/Server.php
+++ b/lib/Server.php
@@ -10,6 +10,8 @@ use Wrench\Application\ConnectionHandlerInterface;
 use Wrench\Application\DataHandlerInterface;
 use Wrench\Application\UpdateHandlerInterface;
 use Wrench\Util\Configurable;
+use Wrench\Util\LoopInterface;
+use Wrench\Util\NullLoop;
 
 /**
  * WebSocket server
@@ -66,6 +68,11 @@ class Server extends Configurable implements LoggerAwareInterface
     protected $connectionManager;
 
     /**
+     * @var LoopInterface
+     */
+    protected $loop;
+
+    /**
      * Applications
      *
      * @var array<string => Application>
@@ -83,6 +90,7 @@ class Server extends Configurable implements LoggerAwareInterface
     {
         $this->uri = $uri;
         $this->logger = new NullLogger();
+        $this->loop = new NullLoop();
 
         parent::__construct($options);
     }
@@ -105,6 +113,11 @@ class Server extends Configurable implements LoggerAwareInterface
         return $this->uri;
     }
 
+    public function setLoop(LoopInterface $loop): void
+    {
+        $this->loop = $loop;
+    }
+
     /**
      * Main server loop
      *
@@ -114,7 +127,7 @@ class Server extends Configurable implements LoggerAwareInterface
     {
         $this->connectionManager->listen();
 
-        while (true) {
+        while ($this->loop->shouldContinue()) {
             /*
              * If there's nothing changed on any of the sockets, the server
              * will sleep and other processes will have a change to run. Control

--- a/lib/Util/LoopInterface.php
+++ b/lib/Util/LoopInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Wrench\Util;
+
+interface LoopInterface
+{
+    public function shouldContinue(): bool;
+}

--- a/lib/Util/NullLoop.php
+++ b/lib/Util/NullLoop.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Wrench\Util;
+
+class NullLoop implements LoopInterface
+{
+    public function shouldContinue(): bool
+    {
+        return true;
+    }
+}

--- a/test/ConnectionTest.php
+++ b/test/ConnectionTest.php
@@ -67,13 +67,7 @@ class ConnectionTest extends BaseTest
             ->getMock();
     }
 
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|ConnectionManager
-     */
-    protected function getMockConnectionManager()
-    {
-        return $this->createMock(ConnectionManager::class);
-    }
+
 
     /**
      * @dataProvider getValidHandshakeData

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -3,6 +3,7 @@
 namespace Wrench;
 
 use Wrench\Test\BaseTest;
+use Wrench\Util\LoopInterface;
 
 /**
  * Tests the Server class
@@ -40,5 +41,32 @@ class ServerTest extends BaseTest
                 'ws://localhost',
             ],
         ];
+    }
+
+    public function testLoop()
+    {
+        /**
+         * A simple loop that only runs 5 times
+         */
+        $countLoop = new class implements LoopInterface
+        {
+            public $count = 0;
+
+            public function shouldContinue(): bool
+            {
+                return ($this->count++ < 5);
+            }
+        };
+
+        $c = $this->getMockConnectionManager();
+
+        $c->expects($this->exactly(5))
+            ->method('selectAndProcess');
+
+        $server = new Server('ws://localhost:8000', [
+            'connection_manager' => $c,
+        ]);
+        $server->setLoop($countLoop);
+        $server->run();
     }
 }

--- a/test/Test/BaseTest.php
+++ b/test/Test/BaseTest.php
@@ -4,6 +4,7 @@ namespace Wrench\Test;
 
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use Wrench\ConnectionManager;
 
 /**
  * Test base class
@@ -57,16 +58,10 @@ abstract class BaseTest extends TestCase
     }
 
     /**
-     * Logging function
-     *
-     * Passed into some classes under test as a callable
-     *
-     * @param string $message
-     * @param string $priority
-     * @return void
+     * @return \PHPUnit_Framework_MockObject_MockObject|ConnectionManager
      */
-    public function log($message, $priority = 'info')
+    protected function getMockConnectionManager()
     {
-        // nothing
+        return $this->createMock(ConnectionManager::class);
     }
 }


### PR DESCRIPTION
Fixes #77

Adds a `LoopInterface`, which consists of the single method `shouldContinue(): bool`. Set the loop on the server with `$server->setLoop(LoopInterface $loop)` at any point before you call `$server->run()`.

Includes a test example which is a loop interface configured to only loop five times: https://github.com/dominics/Wrench/blob/1851fc039338edece476e8606085e260627fa8af/test/ServerTest.php#L48L59