### PR TITLE
fix TypeErrors in calls to connection close

### DIFF
--- a/lib/ConnectionManager.php
+++ b/lib/ConnectionManager.php
@@ -219,17 +219,17 @@ class ConnectionManager extends Configurable implements Countable, LoggerAwareIn
             $this->logger->notice('Client connection closed: {exception}', [
                 'exception' => $e,
             ]);
-            $connection->close($e);
+            $connection->close(Protocol::CLOSE_UNEXPECTED, $e->getMessage());
         } catch (WrenchException $e) {
             $this->logger->warning('Error on client socket: {exception}', [
                 'exception' => $e,
             ]);
-            $connection->close($e);
+            $connection->close(Protocol::CLOSE_UNEXPECTED);
         } catch (InvalidArgumentException $e) {
             $this->logger->warning('Wrong input arguments: {exception}', [
                 'exception' => $e,
             ]);
-            $connection->close($e);
+            $connection->close(Protocol::CLOSE_UNEXPECTED);
         }
     }
 


### PR DESCRIPTION
When running under PHP7, following excpetion occurs: 

> PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Wrench\Connection::close() must be of the type integer, object given, called in .\vendor\wrench\wrench\lib\ConnectionManager.php on line 22

This pull request replaces close calls with object `$connection->close($e);` to correct calls with int `$connection->close(Protocol::CLOSE_UNEXPECTED);`