### PR TITLE
Disable Nagle's algorithm in client sockets

### DIFF
--- a/lib/Socket/ServerSocket.php
+++ b/lib/Socket/ServerSocket.php
@@ -63,6 +63,8 @@ class ServerSocket extends UriSocket
         if (!$new) {
             throw new ConnectionException(socket_strerror(socket_last_error($new)));
         }
+        
+        socket_set_option(socket_import_stream($new), SOL_TCP, TCP_NODELAY, 1);
 
         return $new;
     }


### PR DESCRIPTION
Nagle's algorithm causes messages to be delivered in batches, which causes performance problems in latency critical applications (for example games). 

Nagle's algorithm is turned off be default for WebSocket connections in all major browsers. Many other WebSocket libraries use TCP_NODELAY also.

References:
https://bugs.webkit.org/show_bug.cgi?id=102079
https://groups.google.com/forum/#!topic/native-client-discuss/T8zdrMjiTAE
https://github.com/websockets/ws/issues/791