### PR TITLE
Client received cleanup after each receive call

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -206,9 +206,10 @@ class Client extends Configurable
             return [];
         }
 
-        $old = $this->received;
         $this->payloadHandler->handle($data);
-        return array_diff_assoc($this->received, $old);
+        $received = $this->received;
+        $this->received = [];
+        return $received;
     }
 
     /**

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -130,7 +130,7 @@ class ClientTest extends BaseTest
             $responses = $instance->receive();
             $this->assertTrue(is_array($responses));
             $this->assertCount(1, $responses);
-            $this->assertInstanceOf(Payload::class, $responses[2]);
+            $this->assertInstanceOf(Payload::class, $responses[0]);
 
             $instance->disconnect();
 


### PR DESCRIPTION
/lib/Client.php onData just keeps pushing payloads to the received array without ever cleaning it.

If the Wrench client is run in a loop, the array just keeps growing.
I don't see any reason to keep the previous received messages and calculating the diff on each receive() call.