### PR TITLE
Fix implode() args order for PHP 7.4

### DIFF
--- a/lib/Protocol/Protocol.php
+++ b/lib/Protocol/Protocol.php
@@ -291,7 +291,7 @@ abstract class Protocol
         foreach ($headers as $name => $value) {
             $handshake[] = sprintf(self::HEADER_LINE_FORMAT, $name, $value);
         }
-        return implode($handshake, "\r\n") . "\r\n\r\n";
+        return implode("\r\n", $handshake) . "\r\n\r\n";
     }
 
     /**
@@ -475,7 +475,7 @@ abstract class Protocol
             $handshake[] = sprintf(self::HEADER_LINE_FORMAT, $name, $value);
         }
 
-        return implode($handshake, "\r\n") . "\r\n\r\n";
+        return implode("\r\n", $handshake) . "\r\n\r\n";
     }
 
     /**


### PR DESCRIPTION
PHP 7.4: Deprecated: implode(): Passing glue string after array is deprecated.
