### PR TITLE
Fix php 7.4 compatibility problem related to implode()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.4
   - 7.1
   - 7.0
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.4
   - 7.1
   - 7.0
   - 5.6

--- a/lib/Wrench/Protocol/Protocol.php
+++ b/lib/Wrench/Protocol/Protocol.php
@@ -327,7 +327,7 @@ abstract class Protocol
         foreach ($headers as $name => $value) {
             $handshake[] = sprintf(self::HEADER_LINE_FORMAT, $name, $value);
         }
-        return implode($handshake, "\r\n") . "\r\n\r\n";
+        return implode("\r\n", $handshake) . "\r\n\r\n";
     }
 
     /**
@@ -395,7 +395,7 @@ abstract class Protocol
             $handshake[] = sprintf(self::HEADER_LINE_FORMAT, $name, $value);
         }
 
-        return implode($handshake, "\r\n") . "\r\n\r\n";
+        return implode("\r\n", $handshake) . "\r\n\r\n";
     }
 
     /**


### PR DESCRIPTION
Fix php7.4 deprecation warning for 2.* branch

>  implode(): Passing glue string after array is deprecated. Swap the parameters 