### PR TITLE
Fix deprecation warning on php 7.4

### DIFF
--- a/lib/Wrench/Protocol/Protocol.php
+++ b/lib/Wrench/Protocol/Protocol.php
@@ -327,7 +327,7 @@ abstract class Protocol
         foreach ($headers as $name => $value) {
             $handshake[] = sprintf(self::HEADER_LINE_FORMAT, $name, $value);
         }
-        return implode($handshake, "\r\n") . "\r\n\r\n";
+        return implode("\r\n", $handshake) . "\r\n\r\n";
     }
 
     /**


### PR DESCRIPTION
Swap implode args order to avoid deprecation warnings