### PR TITLE
Glue string is passed first in order avoid the deprecation warning

### DIFF
--- a/lib/Protocol/Protocol.php
+++ b/lib/Protocol/Protocol.php
@@ -291,7 +291,7 @@ abstract class Protocol
         foreach ($headers as $name => $value) {
             $handshake[] = sprintf(self::HEADER_LINE_FORMAT, $name, $value);
         }
-        return implode("\r\n", $handshake) . "\r\n\r\n";
+        return implode($handshake, "\r\n") . "\r\n\r\n";
     }
 
     /**


### PR DESCRIPTION
It seems that PHP 7.4 has deprecated to pass the glue string after the array parameter.

The following deprecation warning was received:

`Deprecated: implode(): Passing glue string after array is deprecated. Swap the parameters`
